### PR TITLE
Add Fathom analytics with email signup event tracking

### DIFF
--- a/src/components/EmailSignup.astro
+++ b/src/components/EmailSignup.astro
@@ -61,6 +61,17 @@ try {
   <p class="signup-note">{subscriberText && <span class="subscriber-count">{subscriberText}</span>} No spam. Unsubscribe anytime.</p>
 </div>
 
+<script>
+  document.querySelectorAll<HTMLFormElement>('.signup-form').forEach((form) => {
+    form.addEventListener('submit', () => {
+      const fathom = (window as any).fathom;
+      if (fathom?.trackEvent) {
+        fathom.trackEvent('Email Signup');
+      }
+    });
+  });
+</script>
+
 <style>
   .signup-box {
     background: var(--color-bg-secondary);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -61,6 +61,7 @@ const categories = categoryOrder.filter(c => allCategories.includes(c));
       };
       document.documentElement.setAttribute('data-theme', getTheme());
     </script>
+    <script src="https://cdn.usefathom.com/script.js" data-site="HYPGQPWK" defer is:inline></script>
   </head>
   <body>
     <div class="scanlines"></div>


### PR DESCRIPTION
## Summary
- Loads Fathom tracking script (site `HYPGQPWK`) in `BaseLayout` so it fires on every page
- Fires an `Email Signup` event from `EmailSignup.astro` when the form is submitted, so we can see which posts drive the most newsletter signups

## Test plan
- [ ] After deploy, load the homepage and confirm Fathom registers a pageview in the dashboard
- [ ] Submit the signup form on a blog post and confirm an `Email Signup` event appears in Fathom with the correct page URL
- [ ] Confirm form still submits to Kit successfully (signup completes end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)